### PR TITLE
Customised mdc keys

### DIFF
--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -3,7 +3,7 @@ kamon {
     // if enabled kamon will set MDC context with TraceID and SpanID valuse
     // they could be referenced using kamonTraceID and kamonSpanID keys
     mdc-context-propagation = on
-    mdc-trace-key = kamonTraceId
-    mdc-span-key = kamonSpanID
+    mdc-trace-id-key = kamonTraceId
+    mdc-span-id-key = kamonSpanID
   }
 }

--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -3,5 +3,7 @@ kamon {
     // if enabled kamon will set MDC context with TraceID and SpanID valuse
     // they could be referenced using kamonTraceID and kamonSpanID keys
     mdc-context-propagation = on
+    mdc-trace-key = kamonTraceId
+    mdc-span-key = kamonSpanID
   }
 }

--- a/src/main/scala/kamon/logback/instrumentation/AsyncAppenderInstrumentation.scala
+++ b/src/main/scala/kamon/logback/instrumentation/AsyncAppenderInstrumentation.scala
@@ -29,10 +29,13 @@ import scala.beans.BeanProperty
 
 object AsyncAppenderInstrumentation {
 
-  @volatile var mdcTraceKey : String = "kamonTraceID"
-  @volatile var mdcSpanKey : String = "kamonSpanID"
+  @volatile private var _mdcContextPropagation: Boolean = true
+  @volatile private var _mdcTraceKey: String = "kamonTraceID"
+  @volatile private var _mdcSpanKey: String = "kamonSpanID"
 
-  @volatile var mdcContextPropagation : Boolean = true
+  def mdcTraceKey: String = _mdcTraceKey
+  def mdcSpanKey: String = _mdcSpanKey
+  def mdcContextPropagation: Boolean = _mdcContextPropagation
 
   loadConfiguration(Kamon.config())
 
@@ -44,9 +47,9 @@ object AsyncAppenderInstrumentation {
 
   private def loadConfiguration(config: Config): Unit = synchronized {
     val logbackConfig = config.getConfig("kamon.logback")
-    mdcContextPropagation = logbackConfig.getBoolean("mdc-context-propagation")
-    mdcTraceKey = logbackConfig.getString("mdc-trace-key")
-    mdcSpanKey = logbackConfig.getString("mdc-span-key")
+    _mdcContextPropagation = logbackConfig.getBoolean("mdc-context-propagation")
+    _mdcTraceKey = logbackConfig.getString("mdc-trace-key")
+    _mdcSpanKey = logbackConfig.getString("mdc-span-key")
   }
 }
 @Aspect

--- a/src/main/scala/kamon/logback/instrumentation/AsyncAppenderInstrumentation.scala
+++ b/src/main/scala/kamon/logback/instrumentation/AsyncAppenderInstrumentation.scala
@@ -48,8 +48,8 @@ object AsyncAppenderInstrumentation {
   private def loadConfiguration(config: Config): Unit = synchronized {
     val logbackConfig = config.getConfig("kamon.logback")
     _mdcContextPropagation = logbackConfig.getBoolean("mdc-context-propagation")
-    _mdcTraceKey = logbackConfig.getString("mdc-trace-key")
-    _mdcSpanKey = logbackConfig.getString("mdc-span-key")
+    _mdcTraceKey = logbackConfig.getString("mdc-trace-id-key")
+    _mdcSpanKey = logbackConfig.getString("mdc-span-id-key")
   }
 }
 @Aspect

--- a/src/main/scala/kamon/logback/instrumentation/AsyncAppenderInstrumentation.scala
+++ b/src/main/scala/kamon/logback/instrumentation/AsyncAppenderInstrumentation.scala
@@ -29,8 +29,8 @@ import scala.beans.BeanProperty
 
 object AsyncAppenderInstrumentation {
 
-  val MdcTraceKey : String = "kamonTraceID"
-  val MdcSpanKey : String = "kamonSpanID"
+  @volatile var mdcTraceKey : String = "kamonTraceID"
+  @volatile var mdcSpanKey : String = "kamonSpanID"
 
   @volatile var mdcContextPropagation : Boolean = true
 
@@ -45,6 +45,8 @@ object AsyncAppenderInstrumentation {
   private def loadConfiguration(config: Config): Unit = synchronized {
     val logbackConfig = config.getConfig("kamon.logback")
     mdcContextPropagation = logbackConfig.getBoolean("mdc-context-propagation")
+    mdcTraceKey = logbackConfig.getString("mdc-trace-key")
+    mdcSpanKey = logbackConfig.getString("mdc-span-key")
   }
 }
 @Aspect
@@ -68,13 +70,13 @@ class AsyncAppenderInstrumentation {
     val context = Kamon.currentContext().get(Span.ContextKey)
 
     if (context.context().traceID != IdentityProvider.NoIdentifier && AsyncAppenderInstrumentation.mdcContextPropagation){
-      MDC.put(AsyncAppenderInstrumentation.MdcTraceKey, context.context().traceID.string)
-      MDC.put(AsyncAppenderInstrumentation.MdcSpanKey, context.context().spanID.string)
+      MDC.put(AsyncAppenderInstrumentation.mdcTraceKey, context.context().traceID.string)
+      MDC.put(AsyncAppenderInstrumentation.mdcSpanKey, context.context().spanID.string)
       try {
         pjp.proceed()
       } finally {
-        MDC.remove(AsyncAppenderInstrumentation.MdcTraceKey)
-        MDC.remove(AsyncAppenderInstrumentation.MdcSpanKey)
+        MDC.remove(AsyncAppenderInstrumentation.mdcTraceKey)
+        MDC.remove(AsyncAppenderInstrumentation.mdcSpanKey)
       }
     } else {
       pjp.proceed()

--- a/src/test/scala/kamon/logback/LogbackSpanConverterSpec.scala
+++ b/src/test/scala/kamon/logback/LogbackSpanConverterSpec.scala
@@ -53,7 +53,7 @@ class LogbackSpanConverterSpec extends WordSpec with Matchers with Eventually {
       }
 
       "MDC context" in {
-        val memoryAppender = buildMemoryAppender(configurator,s"%X{${AsyncAppenderInstrumentation.MdcTraceKey}} %X{${AsyncAppenderInstrumentation.MdcSpanKey}} %X{mdc_key}")
+        val memoryAppender = buildMemoryAppender(configurator,s"%X{${AsyncAppenderInstrumentation.mdcTraceKey}} %X{${AsyncAppenderInstrumentation.mdcSpanKey}} %X{mdc_key}")
 
         val span = Kamon.buildSpan("my-span").start()
         val traceID = span.context().traceID
@@ -66,8 +66,8 @@ class LogbackSpanConverterSpec extends WordSpec with Matchers with Eventually {
         }
 
         memoryAppender.getLastLine shouldBe traceID.string + " " + spanID.string + " mdc_value"
-        MDC.get(AsyncAppenderInstrumentation.MdcTraceKey) shouldBe null
-        MDC.get(AsyncAppenderInstrumentation.MdcSpanKey) shouldBe null
+        MDC.get(AsyncAppenderInstrumentation.mdcTraceKey) shouldBe null
+        MDC.get(AsyncAppenderInstrumentation.mdcSpanKey) shouldBe null
       }
 
       "disable MDC context" in {
@@ -78,7 +78,7 @@ class LogbackSpanConverterSpec extends WordSpec with Matchers with Eventually {
         )
 
 
-        val memoryAppender = buildMemoryAppender(configurator,s"%X{${AsyncAppenderInstrumentation.MdcTraceKey}}")
+        val memoryAppender = buildMemoryAppender(configurator,s"%X{${AsyncAppenderInstrumentation.mdcTraceKey}}")
 
         val span = Kamon.buildSpan("my-span").start()
         val contextWithSpan = Context.create(Span.ContextKey, span)


### PR DESCRIPTION
Hi, I liked mdc support, but needed to have the ability to use standard MDC key names for tracing, so `X-B3-TraceId` and `X-B3-SpanId`, that's why I thought about customising key names through configuration. Tell me what you think about including that in kamon-logback ;)

PS. I would consider to defaulting key names to `X-B3-TraceId` and `X-B3-SpanId` anyway, can do it if you decide to.