### PR TITLE
allow to set different keys to mdc

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,3 +77,5 @@ Context
   // loggers called in this context will have access to the userID, requestID
 }
 ```
+
+Note: While in Kamon you can have one local key and one broadcast key with the same name, in MDC this is not possible. In this case only the broadcast key will be stored in MDC (will be present in the logs) 

--- a/README.md
+++ b/README.md
@@ -62,11 +62,18 @@ If you choose to use [`AsyncAppender`](https://logback.qos.ch/manual/appenders.h
  <pattern>%d{yyyy-MM-dd HH:mm:ss} | %-5level | %X{kamonTraceID} | %X{kamonSpanID} | %c{0} -> %m%n</pattern>
 ```
 
-You can also add custom values to MDC. To do this, simply add the key value in the library configuration: `kamon.logback.mdc-traced-context-keys = [ userID ]`. Then, add the value to the kamon context:
+You can also add custom values to MDC. To do this, simply add the key value in the library configuration: 
+```
+kamon.logback.mdc-traced-local-keys = [ userID ].
+kamon.logback.mdc-traced-broadcast-keys = [ requestID ]
+``` 
+
+Then, add the value to the kamon context:
 ```
 Context
   .create(Span.ContextKey, span)
-  .withKey(Key.broadcastString("userID"), Some("user-1")) {
-  // loggers called in this context will have access to the user ID
+  .withKey(Key.broadcastString("userID"), Some("user-1"))
+  .withKey(Key.local[Option[String]("requestID", None), Some("request-id") {
+  // loggers called in this context will have access to the userID, requestID
 }
 ```

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![Maven Central](https://maven-badges.herokuapp.com/maven-central/io.kamon/kamon-logback_2.12/badge.svg)](https://maven-badges.herokuapp.com/maven-central/io.kamon/kamon-logback_2.12)
 
 
-The <b>kamon-logback</b> module require you to start your application using the AspectJ Weaver Agent.
+The <b>kamon-logback</b> module requires you to start your application using the AspectJ Weaver Agent.
 
 
 ### Getting Started
@@ -21,7 +21,7 @@ To get started with SBT, simply add the following to your `build.sbt` or `pom.xm
 file:
 
 ```scala
-libraryDependencies += "io.kamon" %% "kamon-logback" % "1.0.0"
+libraryDependencies += "io.kamon" %% "kamon-logback" % "1.0.2"
 ```
 
 ```xml
@@ -57,4 +57,16 @@ Inserting a `conversionRule` allows you to incorporate the trace ID for a reques
 Propagating TraceID to AsyncAppender
 ------------------------------------
 
-If you choose to use [`AsyncAppender`](https://logback.qos.ch/manual/appenders.html#AsyncAppender), your trace ID will automatically be propagated to the thread where the log is actually published. No configuration needed. 
+If you choose to use [`AsyncAppender`](https://logback.qos.ch/manual/appenders.html#AsyncAppender), your trace ID will automatically be propagated to the thread where the log is actually published. No configuration needed. The same applies for the span ID. You can use them in the logback pattern like this:
+```xml
+ <pattern>%d{yyyy-MM-dd HH:mm:ss} | %-5level | %X{kamonTraceID} | %X{kamonSpanID} | %c{0} -> %m%n</pattern>
+```
+
+You can also add custom values to MDC. To do this, simply add the key value in the library configuration: `kamon.logback.mdc-traced-context-keys = [ userID ]`. Then, add the value to the kamon context:
+```
+Context
+  .create(Span.ContextKey, span)
+  .withKey(Key.broadcastString("userID"), Some("user-1")) {
+  // loggers called in this context will have access to the user ID
+}
+```

--- a/build.sbt
+++ b/build.sbt
@@ -22,7 +22,7 @@ resolvers += Resolver.bintrayRepo("kamon-io", "snapshots")
 lazy val root = (project in file("."))
   .settings(Seq(
       name := "kamon-logback",
-      scalaVersion := "2.12.3"))
+      scalaVersion := "2.12.6"))
   .settings(aspectJSettings: _*)
   .settings(
     libraryDependencies ++=

--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -3,6 +3,7 @@ kamon {
     // if enabled kamon will set MDC context with TraceID and SpanID valuse
     // they could be referenced using kamonTraceID and kamonSpanID keys
     mdc-context-propagation = on
+    mdc-traced-context-keys = []
     mdc-trace-id-key = kamonTraceId
     mdc-span-id-key = kamonSpanID
   }

--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -3,8 +3,9 @@ kamon {
     // if enabled kamon will set MDC context with TraceID and SpanID valuse
     // they could be referenced using kamonTraceID and kamonSpanID keys
     mdc-context-propagation = on
-    mdc-traced-context-keys = []
     mdc-trace-id-key = kamonTraceId
     mdc-span-id-key = kamonSpanID
+    mdc-traced-local-keys = []
+    mdc-traced-broadcast-keys = []
   }
 }

--- a/src/main/scala/kamon/logback/instrumentation/AsyncAppenderInstrumentation.scala
+++ b/src/main/scala/kamon/logback/instrumentation/AsyncAppenderInstrumentation.scala
@@ -33,12 +33,14 @@ object AsyncAppenderInstrumentation {
   @volatile private var _mdcContextPropagation: Boolean = true
   @volatile private var _mdcTraceKey: String = "kamonTraceID"
   @volatile private var _mdcSpanKey: String = "kamonSpanID"
-  @volatile private var _mdcTracedKeys: Set[String] = Set.empty[String]
+  @volatile private var _mdcLocalKeys: Set[Key[Option[String]]] = Set.empty[Key[Option[String]]]
+  @volatile private var _mdcBroadcastKeys: Set[Key[Option[String]]] = Set.empty[Key[Option[String]]]
 
   def mdcTraceKey: String = _mdcTraceKey
   def mdcSpanKey: String = _mdcSpanKey
   def mdcContextPropagation: Boolean = _mdcContextPropagation
-  def mdcTracedKeys: Set[String] = _mdcTracedKeys
+  def mdcLocalKeys: Set[Key[Option[String]]] = _mdcLocalKeys
+  def mdcBroadcastKeys: Set[Key[Option[String]]] = _mdcBroadcastKeys
 
   loadConfiguration(Kamon.config())
 
@@ -53,9 +55,11 @@ object AsyncAppenderInstrumentation {
     _mdcContextPropagation = logbackConfig.getBoolean("mdc-context-propagation")
     _mdcTraceKey = logbackConfig.getString("mdc-trace-id-key")
     _mdcSpanKey = logbackConfig.getString("mdc-span-id-key")
-    _mdcTracedKeys = logbackConfig.getStringList("mdc-traced-context-keys").asScala.toSet
+    _mdcLocalKeys = logbackConfig.getStringList("mdc-traced-local-keys").asScala.toSet.map { key: String => Key.local[Option[String]](key, None) }
+    _mdcBroadcastKeys = logbackConfig.getStringList("mdc-traced-broadcast-keys").asScala.toSet.map { key: String => Key.broadcastString(key) }
   }
 }
+
 @Aspect
 class AsyncAppenderInstrumentation {
 
@@ -78,19 +82,27 @@ class AsyncAppenderInstrumentation {
     val span = currentContext.get(Span.ContextKey)
 
     if (span.context().traceID != IdentityProvider.NoIdentifier && AsyncAppenderInstrumentation.mdcContextPropagation){
-      AsyncAppenderInstrumentation.mdcTracedKeys.foreach { tracedkey =>
-        currentContext.get(Key.broadcastString(tracedkey)).foreach { tracedKeyValue =>
-          MDC.put(tracedkey, tracedKeyValue)
-        }
-      }
       MDC.put(AsyncAppenderInstrumentation.mdcTraceKey, span.context().traceID.string)
       MDC.put(AsyncAppenderInstrumentation.mdcSpanKey, span.context().spanID.string)
+
+      AsyncAppenderInstrumentation.mdcLocalKeys.foreach { localKey =>
+        currentContext.get(localKey).foreach { localKeyValue =>
+          MDC.put(localKey.name, localKeyValue)
+        }
+      }
+
+      AsyncAppenderInstrumentation.mdcBroadcastKeys.foreach { broadcast =>
+        currentContext.get(broadcast).foreach { broadcastKeyValue =>
+          MDC.put(broadcast.name, broadcastKeyValue)
+        }
+      }
       try {
         pjp.proceed()
       } finally {
         MDC.remove(AsyncAppenderInstrumentation.mdcTraceKey)
         MDC.remove(AsyncAppenderInstrumentation.mdcSpanKey)
-        AsyncAppenderInstrumentation.mdcTracedKeys.foreach(MDC.remove)
+        AsyncAppenderInstrumentation.mdcLocalKeys.foreach(key => MDC.remove(key.name))
+        AsyncAppenderInstrumentation.mdcBroadcastKeys.foreach(key => MDC.remove(key.name))
       }
     } else {
       pjp.proceed()

--- a/src/test/scala/kamon/logback/LogbackSpanConverterSpec.scala
+++ b/src/test/scala/kamon/logback/LogbackSpanConverterSpec.scala
@@ -18,7 +18,7 @@ package kamon.logback
 
 import com.typesafe.config.ConfigFactory
 import kamon.Kamon
-import kamon.context.Context
+import kamon.context.{Context, Key}
 import kamon.logback.instrumentation.AsyncAppenderInstrumentation
 import kamon.trace.Span
 import org.scalatest._
@@ -69,6 +69,45 @@ class LogbackSpanConverterSpec extends WordSpec with Matchers with Eventually {
         MDC.get(AsyncAppenderInstrumentation.mdcTraceKey) shouldBe null
         MDC.get(AsyncAppenderInstrumentation.mdcSpanKey) shouldBe null
       }
+
+      "report the custom MDC keys in the context" in {
+        Kamon.reconfigure(
+          ConfigFactory
+            .parseString("kamon.logback.mdc-traced-context-keys = [ testKey1, testKey2 ]")
+            .withFallback(ConfigFactory.defaultReference()))
+        val memoryAppender = buildMemoryAppender(configurator, "%X{testKey1} %X{testKey2}")
+
+        val span = Kamon.buildSpan("my-span").start()
+        val contextWithSpan = Context
+          .create(Span.ContextKey, span)
+          .withKey(Key.broadcastString("testKey1"), Some("testKey1Value"))
+          .withKey(Key.broadcastString("testKey2"), Some("testKey2Value"))
+
+        Kamon.withContext(contextWithSpan) {
+          memoryAppender.doAppend(createLoggingEvent(context))
+        }
+
+        memoryAppender.getLastLine shouldBe "testKey1Value testKey2Value"
+      }
+
+      "report empty if custom MDC keys are configured, but not provided" in {
+        Kamon.reconfigure(
+          ConfigFactory
+            .parseString("kamon.logback.mdc-traced-context-keys = [ testKey1, testKey2 ]")
+            .withFallback(ConfigFactory.defaultReference()))
+        val memoryAppender = buildMemoryAppender(configurator, "%X{testKey1} %X{testKey2}")
+
+        val span = Kamon.buildSpan("my-span").start()
+        val contextWithSpan = Context
+          .create(Span.ContextKey, span)
+
+        Kamon.withContext(contextWithSpan) {
+          memoryAppender.doAppend(createLoggingEvent(context))
+        }
+
+        memoryAppender.getLastLine shouldBe " "
+      }
+
 
       "disable MDC context" in {
         Kamon.reconfigure(

--- a/src/test/scala/kamon/logback/LogbackSpanConverterSpec.scala
+++ b/src/test/scala/kamon/logback/LogbackSpanConverterSpec.scala
@@ -73,7 +73,7 @@ class LogbackSpanConverterSpec extends WordSpec with Matchers with Eventually {
       "report the custom MDC keys in the context" in {
         Kamon.reconfigure(
           ConfigFactory
-            .parseString("kamon.logback.mdc-traced-context-keys = [ testKey1, testKey2 ]")
+            .parseString("kamon.logback.mdc-traced-broadcast-keys = [ testKey1, testKey2 ]")
             .withFallback(ConfigFactory.defaultReference()))
         val memoryAppender = buildMemoryAppender(configurator, "%X{testKey1} %X{testKey2}")
 
@@ -93,7 +93,7 @@ class LogbackSpanConverterSpec extends WordSpec with Matchers with Eventually {
       "report empty if custom MDC keys are configured, but not provided" in {
         Kamon.reconfigure(
           ConfigFactory
-            .parseString("kamon.logback.mdc-traced-context-keys = [ testKey1, testKey2 ]")
+            .parseString("kamon.logback.mdc-traced-broadcast-keys = [ testKey1, testKey2 ]")
             .withFallback(ConfigFactory.defaultReference()))
         val memoryAppender = buildMemoryAppender(configurator, "%X{testKey1} %X{testKey2}")
 


### PR DESCRIPTION
Now we can set to MDC only traceID, spanID
```scala
      MDC.put(AsyncAppenderInstrumentation.mdcTraceKey, span.context().traceID.string)
      MDC.put(AsyncAppenderInstrumentation.mdcSpanKey, span.context().spanID.string)
```
But if you want to see in logs userId, userIp, you can not do it. 
This pull request allows to define Kamon.context keys which will set to MDC too