### PR TITLE
Clarify README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,20 +15,20 @@ Supported releases and dependencies are shown below.
 
 | kamon  | status | jdk  | scala            
 |:------:|:------:|:----:|------------------
-|  1.0.0 | stable | 1.8+ | 2.10, 2.11, 2.12
+|  1.0.5 | stable | 1.8+ | 2.10, 2.11, 2.12
 
 To get started with SBT, simply add the following to your `build.sbt` or `pom.xml`
 file:
 
 ```scala
-libraryDependencies += "io.kamon" %% "kamon-logback" % "1.0.2"
+libraryDependencies += "io.kamon" %% "kamon-logback" % "1.0.5"
 ```
 
 ```xml
 <dependency>
     <groupId>io.kamon</groupId>
     <artifactId>kamon-logback_2.12</artifactId>
-    <version>1.0.0</version>
+    <version>1.0.5</version>
 </dependency>
 ```
 


### PR DESCRIPTION
Update `kamon-logback` version in README.md to reflect that the feature to add custom values to MDC was only added in v1.0.3

Add logback.xml example to AsyncAppender to clarify how `AsyncAppenderInstrumentation` is configured.