### PR TITLE
Allow any type of broadcast key to be put into the MDC

### DIFF
--- a/src/test/scala/kamon/logback/LogbackSpanConverterSpec.scala
+++ b/src/test/scala/kamon/logback/LogbackSpanConverterSpec.scala
@@ -81,7 +81,7 @@ class LogbackSpanConverterSpec extends WordSpec with Matchers with Eventually {
         val contextWithSpan = Context
           .create(Span.ContextKey, span)
           .withKey(Key.broadcastString("testKey1"), Some("testKey1Value"))
-          .withKey(Key.broadcastString("testKey2"), Some("testKey2Value"))
+          .withKey(Key.broadcast("testKey2", ""), "testKey2Value")
 
         Kamon.withContext(contextWithSpan) {
           memoryAppender.doAppend(createLoggingEvent(context))


### PR DESCRIPTION
This change is in connection to https://gitter.im/kamon-io/Kamon?at=5c34a77dbd592b2e6e6fbd46 and kamon-io#14

Currently when MDC propagation is on, if a service is configured to use a Broadcast key other then Option[String], we lose logging.

Allow any broadcast key to be put into the MDC, not only Option[String] as it is now.