### PR TITLE
A appender that counts log entries

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,3 +79,36 @@ Context
 ```
 
 Note: While in Kamon you can have one local key and one broadcast key with the same name, in MDC this is not possible. In this case only the broadcast key will be stored in MDC (will be present in the logs) 
+
+Counting Log Entries
+--------------------
+
+Sometimes you need to know how many log entries your application produce as a Kamon counter, in order to easily visualize that information, and more important, be able to alert on those metrics.
+
+This library allows you to do that by just changing the logback.xml file and adding a simple appender, please notice the appender called COUNTER:
+
+
+```xml
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration scan="false" debug="false">
+  <conversionRule conversionWord="traceID" converterClass="kamon.logback.LogbackTraceIDConverter" />
+
+  <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+    <encoder>
+      <pattern>%d{yyyy-MM-dd HH:mm:ss} | %-5level | %traceID | %c{0} -> %m%n</pattern>
+    </encoder>
+  </appender>
+  <appender name="COUNTER" class="kamon.logback.LogbackEntriesCounterAppender"/>
+
+  <root level="DEBUG">
+    <appender-ref ref="STDOUT" />
+    <appender-ref ref="COUNTER" />
+  </root>
+</configuration>
+```
+
+The Kamon counter is named "log.events", and is refined with the tags: 
+
+"level" → "ERROR", "WARN", "INFO", "DEBUG", "TRACE" (One of those values, is the level of the event.)
+
+"component" → "logback" (Always this value)

--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -7,5 +7,9 @@ kamon {
     mdc-span-id-key = kamonSpanID
     mdc-traced-local-keys = []
     mdc-traced-broadcast-keys = []
+    entries-counter {
+      metric-name = log-entries-counter
+      level-tag-name = level
+    }
   }
 }

--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -7,9 +7,5 @@ kamon {
     mdc-span-id-key = kamonSpanID
     mdc-traced-local-keys = []
     mdc-traced-broadcast-keys = []
-    entries-counter {
-      metric-name = log-entries-counter
-      level-tag-name = level
-    }
   }
 }

--- a/src/main/scala/kamon/logback/LogbackEntriesCounterAppender.scala
+++ b/src/main/scala/kamon/logback/LogbackEntriesCounterAppender.scala
@@ -7,14 +7,14 @@ import LogbackEntriesCounterAppender._
 
 class LogbackEntriesCounterAppender extends UnsynchronizedAppenderBase[ILoggingEvent] {
 
-  private val counter = Kamon.counter(CounterName)
-
   protected def append(event: ILoggingEvent): Unit =
     counter.refine(LevelTagName → event.getLevel.levelStr).increment()
+
 }
 
 object LogbackEntriesCounterAppender{
   private val appenderConfig = Kamon.config().getConfig("kamon.logback.entries-counter")
   private[logback] val CounterName = appenderConfig.getString("metric-name")
   private[logback] val LevelTagName = appenderConfig.getString("level-tag-name")
+  private[logback] val counter = Kamon.counter(CounterName)
 }

--- a/src/main/scala/kamon/logback/LogbackEntriesCounterAppender.scala
+++ b/src/main/scala/kamon/logback/LogbackEntriesCounterAppender.scala
@@ -1,0 +1,18 @@
+package kamon.logback
+
+import ch.qos.logback.classic.spi.ILoggingEvent
+import ch.qos.logback.core.UnsynchronizedAppenderBase
+import kamon.Kamon
+import LogbackEntriesCounterAppender._
+
+class LogbackEntriesCounterAppender extends UnsynchronizedAppenderBase[ILoggingEvent] {
+
+  protected def append(event: ILoggingEvent): Unit =
+    Kamon.counter(CounterName).refine(LevelTagName → event.getLevel.levelStr).increment()
+}
+
+object LogbackEntriesCounterAppender{
+  private val appenderConfig = Kamon.config().getConfig("kamon.logback.entries-counter")
+  private[logback] val CounterName = appenderConfig.getString("metric-name")
+  private[logback] val LevelTagName = appenderConfig.getString("level-tag-name")
+}

--- a/src/main/scala/kamon/logback/LogbackEntriesCounterAppender.scala
+++ b/src/main/scala/kamon/logback/LogbackEntriesCounterAppender.scala
@@ -8,13 +8,13 @@ import LogbackEntriesCounterAppender._
 class LogbackEntriesCounterAppender extends UnsynchronizedAppenderBase[ILoggingEvent] {
 
   protected def append(event: ILoggingEvent): Unit =
-    counter.refine(LevelTagName → event.getLevel.levelStr).increment()
+    counter.refine(LevelTagName → event.getLevel.levelStr, ComponentTag).increment()
 
 }
 
 object LogbackEntriesCounterAppender{
-  private val appenderConfig = Kamon.config().getConfig("kamon.logback.entries-counter")
-  private[logback] val CounterName = appenderConfig.getString("metric-name")
-  private[logback] val LevelTagName = appenderConfig.getString("level-tag-name")
+  private[logback] val CounterName = "log.events"
+  private[logback] val LevelTagName = "level"
+  private[logback] val ComponentTag = "component" → "logback"
   private[logback] val counter = Kamon.counter(CounterName)
 }

--- a/src/main/scala/kamon/logback/LogbackEntriesCounterAppender.scala
+++ b/src/main/scala/kamon/logback/LogbackEntriesCounterAppender.scala
@@ -7,8 +7,10 @@ import LogbackEntriesCounterAppender._
 
 class LogbackEntriesCounterAppender extends UnsynchronizedAppenderBase[ILoggingEvent] {
 
+  private val counter = Kamon.counter(CounterName)
+
   protected def append(event: ILoggingEvent): Unit =
-    Kamon.counter(CounterName).refine(LevelTagName → event.getLevel.levelStr).increment()
+    counter.refine(LevelTagName → event.getLevel.levelStr).increment()
 }
 
 object LogbackEntriesCounterAppender{

--- a/src/test/resources/reference.conf
+++ b/src/test/resources/reference.conf
@@ -1,0 +1,7 @@
+kamon {
+  metric {
+    tick-interval = 1s
+  }
+}
+
+

--- a/src/test/scala/kamon/logback/KamonMemoryMetricReporter.scala
+++ b/src/test/scala/kamon/logback/KamonMemoryMetricReporter.scala
@@ -1,0 +1,25 @@
+package kamon.logback
+
+import com.typesafe.config.Config
+import kamon.MetricReporter
+import kamon.metric.{MetricValue, PeriodSnapshot}
+
+class KamonMemoryMetricReporter extends MetricReporter {
+
+  def start(): Unit = Unit
+  def stop(): Unit = Unit
+  def reconfigure(config: Config): Unit = Unit
+
+  @volatile var counters: List[MetricValue] = Nil
+
+  def countersTotalByTag(counterName: String, tagName: String): Map[String, Long] =
+    counters.collect{
+      case MetricValue(`counterName`, tags, _, value) if tags.contains(tagName) ⇒
+        (tags(tagName), value)
+    }.groupBy(_._1).mapValues(_.map(_._2).sum)
+
+  def reportPeriodSnapshot(snapshot: PeriodSnapshot): Unit =
+    counters ++= snapshot.metrics.counters
+
+
+}

--- a/src/test/scala/kamon/logback/LogbackEntriesCounterAppenderSpec.scala
+++ b/src/test/scala/kamon/logback/LogbackEntriesCounterAppenderSpec.scala
@@ -1,0 +1,43 @@
+package kamon.logback
+
+import ch.qos.logback.classic.{Level, LoggerContext}
+import ch.qos.logback.classic.spi.ILoggingEvent
+import ch.qos.logback.core.Appender
+import kamon.Kamon
+import kamon.logback.LogbackEntriesCounterAppender._
+import kamon.logback.util.LogbackConfigurator
+import org.scalatest._
+import org.scalatest.concurrent.Eventually
+import org.scalatest.time.SpanSugar._
+
+class LogbackEntriesCounterAppenderSpec extends WordSpec with Matchers with Eventually {
+
+  "LogbackEntriesCounterAppender" when {
+    "a event is logged" should {
+      "count it split by event level" in {
+        implicit val ctx: LoggerContext = context
+        implicit val appender: Appender[ILoggingEvent] = new LogbackEntriesCounterAppender
+
+        val configurator = new LogbackConfigurator(ctx)
+        configurator.appender("entriesCounter", appender)
+
+        val reporter = new KamonMemoryMetricReporter
+        Kamon.addReporter(reporter)
+
+        logMany(5, Level.ERROR)
+        logMany(2, Level.INFO)
+        logMany(1, Level.WARN)
+        logMany(9, Level.DEBUG)
+        logMany(2, Level.ERROR)
+        logMany(1, Level.DEBUG)
+
+        eventually(timeout(3 seconds)) {
+          reporter.counters.size should be > 0
+          reporter.countersTotalByTag(CounterName, LevelTagName) shouldBe
+            Map("ERROR" → 7, "INFO" → 2, "WARN" → 1, "DEBUG" → 10)
+        }
+      }
+    }
+  }
+
+}

--- a/src/test/scala/kamon/logback/package.scala
+++ b/src/test/scala/kamon/logback/package.scala
@@ -56,7 +56,10 @@ package object logback {
     appender
   }
 
-  def createLoggingEvent(loggerContext: LoggerContext): LoggingEvent = {
-    new LoggingEvent(this.getClass.getName, loggerContext.getLogger("ROOT"), Level.DEBUG, "test message", null, null)
+  def createLoggingEvent(loggerContext: LoggerContext, level: Level = Level.DEBUG): LoggingEvent = {
+    new LoggingEvent(this.getClass.getName, loggerContext.getLogger("ROOT"), level, "test message", null, null)
   }
+
+  def logMany(times: Int, level: Level)(implicit appender: Appender[ILoggingEvent], loggerContext: LoggerContext): Unit =
+    for(_ ← 1 to times) { appender.doAppend(createLoggingEvent(context, level)) }
 }


### PR DESCRIPTION
Hello, I would like to give you a little bit of context

My name is Octavio and I work at Fedex. We got the need for counting every log entry as a Kamon metric, that way we can easily visualize, and most important, make alerts based on the log counts.

I created this appender that will count each log entry, split by level, so it can be extract as a regular metric. The main advantage is that no code change is needed, just the logback XML configuration.

Would you please consider merging this PR?

Thanks for your consideration.