### PR TITLE
Restore the complete MDC after propagation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,13 @@ script:
   - sbt +test && sbt -Dagent=kanela +test
 scala:
    - 2.12.4
-jdk:
-   - oraclejdk8
+env:
+  matrix:
+    - TRAVIS_JDK=adopt@1.8.202-08
+before_install:
+  - curl -Ls https://git.io/jabba | bash && . ~/.jabba/jabba.sh
+install:
+  - jabba install "$TRAVIS_JDK" && jabba use $_ && java -Xmx32m -version
 before_script:
   - mkdir $TRAVIS_BUILD_DIR/tmp
   - export SBT_OPTS="-Djava.io.tmpdir=$TRAVIS_BUILD_DIR/tmp"


### PR DESCRIPTION
This saves the MDC before propagation and restores it afterwards. 
I don't know if there are issues with this approach. Let me know what you think.

Would fix #23 