### PR TITLE
move appender loop instrumentation from interceptor to advice, fixes #28

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ script:
 scala:
    - 2.12.4
 jdk:
-   - oraclejdk8
+   - openjdk8
 before_script:
   - mkdir $TRAVIS_BUILD_DIR/tmp
   - export SBT_OPTS="-Djava.io.tmpdir=$TRAVIS_BUILD_DIR/tmp"


### PR DESCRIPTION
For some reason that I couldn't discover just yet, the interceptor for the appender loop is not working as expected when attaching at runtime, but works nice with -javaagent. Changing it to be an advice makes it work on both situations.